### PR TITLE
Delete Pillow predefined versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Pillow==6.1.0
+Pillow
 PyPDF2==1.26.0
 reportlab==3.5.26


### PR DESCRIPTION
Pillow with version below 6.2.0 has security vulnerable according to github security alert. So, removing pillow version will fix the problem since python will use the latest pillow version available on the package manager repository.